### PR TITLE
fix: define my_undefined_data_path in process_data to resolve NameError

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,8 +10,8 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # FIX: Define the missing variable as a placeholder. Update as needed.
+    my_undefined_data_path = "/path/to/data"  # TODO: Update this path as appropriate
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This PR fixes a NameError in the `process_data` function of `runtime_name_error_dag.py` by defining the missing variable `my_undefined_data_path` as a placeholder string. Please update the path as appropriate for your environment.

- Defined `my_undefined_data_path = "/path/to/data"` in `process_data`
- Added a comment to clarify the placeholder

Closes #<issue_number_if_applicable>