### PR TITLE
Fix DAG errors based on log analysis (2025-08-22)

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,8 +10,8 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # FIX: Define the variable before using it
+    my_undefined_data_path = "/tmp/data"  # <-- Added default path
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 

--- a/dags/runtime_sensor_timeout_dag.py
+++ b/dags/runtime_sensor_timeout_dag.py
@@ -23,7 +23,8 @@ with DAG(
         object="sample/file_that_will_never_exist.txt",
         mode="poke", # 'poke' mode keeps the worker slot busy
         poke_interval=10,
-        timeout=60, # Fail the task after 60 seconds of waiting
+        timeout=120, # Increased timeout from 60 to 120 seconds for reliability
+        # NOTE: If this sensor times out, check if the file is being created as expected or increase the timeout further.
     )
 
     task_that_will_be_skipped = BashOperator(

--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -13,11 +13,9 @@ def pull_and_do_math(**context):
     """Pulls the XCom value and tries to perform math with it."""
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
-    
-    # THE ERROR IS HERE: You cannot add a string and an integer.
-    # This will raise a TypeError.
-    result = pulled_value + 100
-    logging.info(f"This will not be logged. The result was {result}")
+    # FIX: Convert to int before adding
+    result = int(pulled_value) + 100
+    logging.info(f"The result was {result}")
 
 with DAG(
     dag_id="runtime_xcom_type_error_dag",


### PR DESCRIPTION
This PR addresses the following issues found in the error log analysis:

1. **runtime_name_error_dag.py**: Defines `my_undefined_data_path` before usage in `process_data` to resolve NameError.
2. **runtime_xcom_type_error_dag.py**: Converts `pulled_value` to `int` before math operation to resolve TypeError.
3. **runtime_sensor_timeout_dag.py**: Increases sensor timeout and adds a troubleshooting note for sensor timeouts.

IAM/BigQuery permission changes are not included as per request.

Please review and merge if the changes look good.