### PR TITLE
Fix runtime errors from log analysis

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/tmp/data"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 

--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,7 +16,7 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR fixes two runtime errors that were identified in the error logs:

- **TypeError**: In `runtime_xcom_type_error_dag.py`, the code was trying to add a string and an integer. This has been fixed by casting the string to an integer before the addition.
- **NameError**: In `runtime_name_error_dag.py`, the code was using an undefined variable. This has been fixed by defining the variable with a temporary path.

The `AirflowSensorTimeout` and the `Forbidden` errors could not be fixed and require manual intervention.