### PR TITLE
Fix multiple runtime errors

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/path/to/data"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 

--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,7 +16,7 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR fixes two runtime errors found in the logs:

- **TypeError:** In `runtime_xcom_type_error_dag.py`, a `TypeError` was occurring because of an attempt to add a string and an integer. This has been fixed by casting the string to an integer before the operation.
- **NameError:** In `runtime_name_error_dag.py`, a `NameError` was occurring because the `my_undefined_data_path` variable was not defined. This has been fixed by defining the variable. Please note that a placeholder value has been used and you may need to update it to a correct path.

**Manual Actions Required:**

- **Permission Error:** The logs show a `google.api_core.exceptions.Forbidden` error. This indicates that the service account running the Airflow tasks does not have the `bigquery.jobs.create` permission in the `tmaf-dev` project. Please grant this permission in the Google Cloud IAM console.
- **Sensor Timeout:** The logs show an `airflow.exceptions.AirflowSensorTimeout` error. This means the sensor `wait_for_nonexistent_file` is timing out. You may need to investigate why the file is not appearing or increase the timeout for the sensor.