### PR TITLE
Fix for multiple runtime errors in DAGs

### DIFF
--- a/dags/python_runtime_error_dag.py
+++ b/dags/python_runtime_error_dag.py
@@ -9,7 +9,8 @@ def cause_a_division_by_zero_error():
     This function will always fail with a ZeroDivisionError.
     """
     logging.info("This task is about to fail...")
-    result = 1 / 0
+    # FIX: Changed the divisor to 1 to prevent ZeroDivisionError.
+    result = 1 / 1
     logging.info(f"This line will never be reached. Result was {result}")
 
 with DAG(

--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,9 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    # FIX: Define the variable my_undefined_data_path. 
+    # Please update this path to the correct location of your data.
+    my_undefined_data_path = "/path/to/your/data"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 

--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,7 +16,8 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    # FIX: Cast the pulled value to an integer before performing the addition.
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This pull request includes fixes for the following runtime errors:

- **NameError:** Defined the missing variable `my_undefined_data_path` in `runtime_name_error_dag.py`.
- **TypeError:** Casted the XCom value to an integer in `runtime_xcom_type_error_dag.py` to prevent a concatenation error.
- **ZeroDivisionError:** Changed the divisor to a non-zero value in `python_runtime_error_dag.py` to prevent a division by zero error.

**Note:** The `Forbidden` error related to BigQuery permissions could not be resolved with code changes. Please ensure the service account has the `bigquery.jobs.create` IAM permission in the `tmaf-dev` project.