### PR TITLE
Fix runtime errors in DAGs

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/tmp"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 

--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,7 +16,7 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR fixes two runtime errors identified from the logs:

1.  **NameError:** In `runtime_name_error_dag.py`, `my_undefined_data_path` was not defined. This has been fixed by initializing the variable.
2.  **TypeError:** In `runtime_xcom_type_error_dag.py`, an attempt to add a string and an integer was made. This has been resolved by casting the string to an integer before the operation.

Additionally, a `Forbidden` error was found in the logs related to BigQuery permissions. This error requires manual intervention to grant the `bigquery.jobs.create` permission to the service account.