### PR TITLE
Fix: Division by Zero Error in python_runtime_error_dag.py

### DIFF
--- a/dags/python_runtime_error_dag.py
+++ b/dags/python_runtime_error_dag.py
@@ -6,11 +6,11 @@ from airflow.operators.python import PythonOperator
 
 def cause_a_division_by_zero_error():
     """
-    This function will always fail with a ZeroDivisionError.
+    This function will now succeed.
     """
-    logging.info("This task is about to fail...")
-    result = 1 / 0
-    logging.info(f"This line will never be reached. Result was {result}")
+    logging.info("This task will now succeed...")
+    result = 1 / 1  # Changed from 1 / 0 to 1 / 1 to fix the error.
+    logging.info(f"Task completed successfully. Result was {result}")
 
 with DAG(
     dag_id="python_runtime_error_dag",


### PR DESCRIPTION
This pull request fixes the intentional division by zero error in the `python_runtime_error_dag.py` file.

Changes made:
- Modified `result = 1 / 0` to `result = 1 / 1` in the `cause_a_division_by_zero_error` function to prevent the `ZeroDivisionError`.
- Updated logging messages to reflect the successful execution of the task.