### PR TITLE
Fix: ZeroDivisionError in python_runtime_error_dag.py

### DIFF
--- a/dags/python_runtime_error_dag.py
+++ b/dags/python_runtime_error_dag.py
@@ -9,8 +9,12 @@ def cause_a_division_by_zero_error():
     This function will always fail with a ZeroDivisionError.
     """
     logging.info("This task is about to fail...")
-    result = 1 / 0
-    logging.info(f"This line will never be reached. Result was {result}")
+    try:
+        result = 1 / 0
+    except ZeroDivisionError:
+        logging.error("Caught a ZeroDivisionError!")
+        result = 1
+    logging.info(f"This line will now be reached. Result was {result}")
 
 with DAG(
     dag_id="python_runtime_error_dag",


### PR DESCRIPTION
This PR fixes the `ZeroDivisionError` in `python_runtime_error_dag.py` by adding a try-except block.