### PR TITLE
Fix: TypeError in runtime_xcom_type_error_dag.py

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -14,10 +14,9 @@ def pull_and_do_math(**context):
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
     
-    # THE ERROR IS HERE: You cannot add a string and an integer.
-    # This will raise a TypeError.
-    result = pulled_value + 100
-    logging.info(f"This will not be logged. The result was {result}")
+    # THE FIX IS HERE: Cast the string to an integer before adding.
+    result = int(pulled_value) + 100
+    logging.info(f"This will now be logged. The result was {result}")
 
 with DAG(
     dag_id="runtime_xcom_type_error_dag",


### PR DESCRIPTION
This PR fixes the `TypeError` in `runtime_xcom_type_error_dag.py` by casting the XCom value to an integer before performing addition.