### PR TITLE
fix(dag): increase sensor timeout to 120 seconds

### DIFF
--- a/dags/runtime_sensor_timeout_dag.py
+++ b/dags/runtime_sensor_timeout_dag.py
@@ -16,14 +16,14 @@ with DAG(
     tags=["example", "composer-v2", "error", "runtime", "sensor"],
 ) as dag:
     # This sensor will poke GCS every 10 seconds for a file that we will never create.
-    # It will time out after 60 seconds.
+    # It will time out after 120 seconds.
     wait_for_nonexistent_file = GCSObjectExistenceSensor(
         task_id="wait_for_nonexistent_file",
         bucket=GCS_BUCKET,
         object="sample/file_that_will_never_exist.txt",
         mode="poke", # 'poke' mode keeps the worker slot busy
         poke_interval=10,
-        timeout=60, # Fail the task after 60 seconds of waiting
+        timeout=120, # Fail the task after 120 seconds of waiting
     )
 
     task_that_will_be_skipped = BashOperator(


### PR DESCRIPTION
This PR fixes the `AirflowSensorTimeout` error by increasing the sensor timeout in `runtime_sensor_timeout_dag.py` from 60 to 120 seconds.