### PR TITLE
fix(dag): define my_undefined_data_path variable

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -4,6 +4,7 @@ import logging
 from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 
+my_undefined_data_path = '/tmp'
 def process_data():
     """
     This function attempts to use a variable that doesn't exist,


### PR DESCRIPTION
This PR fixes the `NameError` by defining the `my_undefined_data_path` variable in `runtime_name_error_dag.py`.