### PR TITLE
fix(dag): Correct SQL typo in BigQuery DAG

### DIFF
--- a/dags/runtime_bigquery_sql_error_dag.py
+++ b/dags/runtime_bigquery_sql_error_dag.py
@@ -20,7 +20,7 @@ with DAG(
         task_id="failing_sql_query_task",
         configuration={
             "query": {
-                "query": f"SELEC 1 AS value FROM `{GCP_PROJECT_ID}.{BIGQUERY_DATASET}.logs` LIMIT 1;",
+                "query": f"SELECT 1 AS value FROM `{GCP_PROJECT_ID}.{BIGQUERY_DATASET}.logs` LIMIT 1;",
                 "useLegacySql": False,
                 "destinationTable": {
                     "projectId": GCP_PROJECT_ID,


### PR DESCRIPTION
This pull request corrects a SQL typo ('SELEC' to 'SELECT') in the runtime_bigquery_sql_error_dag.