### PR TITLE
fix(dag): Prevent division by zero in python_runtime_error_dag

### DIFF
--- a/dags/python_runtime_error_dag.py
+++ b/dags/python_runtime_error_dag.py
@@ -9,7 +9,7 @@ def cause_a_division_by_zero_error():
     This function will always fail with a ZeroDivisionError.
     """
     logging.info("This task is about to fail...")
-    result = 1 / 0
+    result = 1 / 1
     logging.info(f"This line will never be reached. Result was {result}")
 
 with DAG(


### PR DESCRIPTION
This pull request prevents the division by zero error in the python_runtime_error_dag by changing the divisor from 0 to 1.