### PR TITLE
fix(dag): Define missing variable in runtime_name_error_dag

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -1,3 +1,4 @@
+
 import pendulum
 import logging
 
@@ -12,6 +13,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/path/to/data"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This pull request fixes a NameError in the runtime_name_error_dag by defining the my_undefined_data_path variable.