### PR TITLE
Fix: Runtime XCom TypeError in runtime_xcom_type_error_dag.py

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -5,19 +5,19 @@ from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 
 def push_a_string_value(**context):
-    """Pushes a string value to XComs."""
-    logging.info("Pushing the string '500' to XComs.")
-    context["ti"].xcom_push(key="my_value", value="500")
+    """Pushes an integer value to XComs."""
+    logging.info("Pushing the integer 500 to XComs.")
+    context["ti"].xcom_push(key="my_value", value=500)
 
 def pull_and_do_math(**context):
     """Pulls the XCom value and tries to perform math with it."""
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
-    
-    # THE ERROR IS HERE: You cannot add a string and an integer.
-    # This will raise a TypeError.
+
+    # The original error was that a string was added to an integer.
+    # Now, with 'value=500', pulled_value will be an integer, so this operation is valid.
     result = pulled_value + 100
-    logging.info(f"This will not be logged. The result was {result}")
+    logging.info(f"The result was {result}")
 
 with DAG(
     dag_id="runtime_xcom_type_error_dag",


### PR DESCRIPTION
This PR fixes a TypeError in `runtime_xcom_type_error_dag.py` by changing the XCom pushed value from a string to an integer. This ensures that the downstream task can perform arithmetic operations correctly.