### PR TITLE
Fix: Define my_undefined_data_path in runtime_name_error_dag.py

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,8 +10,8 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # Fix: Define my_undefined_data_path
+    my_undefined_data_path = "data/input"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This PR fixes a NameError in `dags/runtime_name_error_dag.py` by defining `my_undefined_data_path` within the `process_data` function. The variable was previously undeclared, causing a runtime error. This change assigns it the value "data/input" to resolve the issue.