### PR TITLE
Fix: Correct import error in DAG

### DIFF
--- a/dags/dag_with_import_error.py
+++ b/dags/dag_with_import_error.py
@@ -10,8 +10,7 @@ with DAG(
     schedule=None,
     catchup=False,
     tags=["example", "composer-v2", "error", "import-error"],
-# The closing parenthesis is missing on the line below!
-as dag:
+) as dag:
     correct_task = BashOperator(
         task_id="this_will_never_run",
         bash_command="echo 'This task is part of a broken DAG.'",


### PR DESCRIPTION
This PR fixes an import error in the `dag_with_import_error.py` DAG by adding a missing closing parenthesis.