### PR TITLE
Fix: Define my_undefined_data_path to prevent NameError

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/tmp/data" #FIX: Defined the variable to fix NameError. Replace with a real path.
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This PR fixes a NameError in `dags/runtime_name_error_dag.py` by defining `my_undefined_data_path`.

Previously, the `process_data` function attempted to use `my_undefined_data_path` without it being defined, leading to a runtime error. This change initializes the variable to a placeholder path, resolving the `NameError`.