### PR TITLE
Fix: ZeroDivisionError in python_runtime_error_dag.py

### DIFF
--- a/dags/python_runtime_error_dag.py
+++ b/dags/python_runtime_error_dag.py
@@ -9,7 +9,7 @@ def cause_a_division_by_zero_error():
     This function will always fail with a ZeroDivisionError.
     """
     logging.info("This task is about to fail...")
-    result = 1 / 0
+    result = 1 / 1 # Changed from 1/0 to fix ZeroDivisionError
     logging.info(f"This line will never be reached. Result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR fixes the ZeroDivisionError in python_runtime_error_dag.py by changing the divisor to a non-zero value.