### PR TITLE
Fix: Runtime XCom TypeError in runtime_xcom_type_error_dag.py

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -14,10 +14,9 @@ def pull_and_do_math(**context):
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
     
-    # THE ERROR IS HERE: You cannot add a string and an integer.
-    # This will raise a TypeError.
-    result = pulled_value + 100
-    logging.info(f"This will not be logged. The result was {result}")
+    # Fixed: Cast pulled_value to an integer before performing addition.
+    result = int(pulled_value) + 100
+    logging.info(f"The result was {result}")
 
 with DAG(
     dag_id="runtime_xcom_type_error_dag",


### PR DESCRIPTION
This PR fixes a `TypeError` in `dags/runtime_xcom_type_error_dag.py` by casting the XCom pulled value to an integer before performing mathematical operations. This ensures that the DAG runs successfully without runtime errors related to type mismatches.