### PR TITLE
Fix: Define my_undefined_data_path to resolve NameError in runtime_name_error_dag.py

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,10 +10,10 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # Define my_undefined_data_path to fix the NameError
+    my_undefined_data_path = "/tmp/data"
     data_path = my_undefined_data_path + "/source.csv"
-    logging.info(f"This will never be logged. Path was: {data_path}")
+    logging.info(f"Data path was: {data_path}")
 
 with DAG(
     dag_id="runtime_name_error_dag",


### PR DESCRIPTION
This PR fixes the NameError in `dags/runtime_name_error_dag.py` by defining `my_undefined_data_path` within the `process_data` function.