### PR TITLE
Docs: Add comment for BigQuery permission requirement

### DIFF
--- a/dags/runtime_bigquery_sql_error_dag.py
+++ b/dags/runtime_bigquery_sql_error_dag.py
@@ -14,7 +14,10 @@ with DAG(
     catchup=False,
     tags=["example", "composer-v2", "error", "runtime", "gcp"],
 ) as dag:
-    # The SQL syntax here is intentionally wrong ('SELEC' instead of 'SELECT').
+    # This task requires the service account to have the `bigquery.jobs.create`
+    # permission in the `tmaf-dev` project. If you encounter a 403 Forbidden error,
+    # please grant the necessary IAM permission to the Airflow service account.
+    # The SQL syntax here is intentionally wrong (\'SELEC\' instead of \'SELECT\').
     # BigQuery will reject this query.
     failing_sql_query = BigQueryInsertJobOperator(
         task_id="failing_sql_query_task",


### PR DESCRIPTION
This PR adds a comment to `runtime_bigquery_sql_error_dag.py` to inform users about the required `bigquery.jobs.create` permission for the service account. This is a documentation-only change to guide users in resolving 403 Forbidden errors related to BigQuery.