### PR TITLE
Docs: Add note about BigQuery permissions in runtime_bigquery_sql_error_dag.py

### DIFF
--- a/dags/runtime_bigquery_sql_error_dag.py
+++ b/dags/runtime_bigquery_sql_error_dag.py
@@ -1,3 +1,5 @@
+# This DAG requires the service account running Airflow tasks to have the bigquery.jobs.create permission.
+# If you encounter 403 Forbidden errors, please ensure the service account has the necessary IAM roles.
 import pendulum
 
 from airflow.models.dag import DAG


### PR DESCRIPTION
This PR adds a comment to runtime_bigquery_sql_error_dag.py to inform users about the required 'bigquery.jobs.create' permission for the service account.