### PR TITLE
Fix: Define my_undefined_data_path in runtime_name_error_dag.py

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,10 +10,10 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # Define the missing variable with a placeholder value
+    my_undefined_data_path = "/tmp/data"
     data_path = my_undefined_data_path + "/source.csv"
-    logging.info(f"This will never be logged. Path was: {data_path}")
+    logging.info(f"Processing data from: {data_path}")
 
 with DAG(
     dag_id="runtime_name_error_dag",


### PR DESCRIPTION
This PR defines the 'my_undefined_data_path' variable in the 'process_data' function within 'runtime_name_error_dag.py' to resolve the NameError.