### PR TITLE
Fix: Handle TypeError by string concatenation for XCom value

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,8 +16,8 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
-    logging.info(f"This will not be logged. The result was {result}")
+    result = pulled_value + "100"
+    logging.info(f"The result was {result}")
 
 with DAG(
     dag_id="runtime_xcom_type_error_dag",


### PR DESCRIPTION
This pull request handles the TypeError in `runtime_xcom_type_error_dag.py` by converting the integer 100 to a string and concatenating it with the pulled XCom value, as per the user's request.