### PR TITLE
Fix: Increase sensor timeout in runtime_sensor_timeout_dag.py

### DIFF
--- a/dags/runtime_sensor_timeout_dag.py
+++ b/dags/runtime_sensor_timeout_dag.py
@@ -23,7 +23,7 @@ with DAG(
         object="sample/file_that_will_never_exist.txt",
         mode="poke", # 'poke' mode keeps the worker slot busy
         poke_interval=10,
-        timeout=60, # Fail the task after 60 seconds of waiting
+        timeout=120, # Fail the task after 120 seconds of waiting
     )
 
     task_that_will_be_skipped = BashOperator(


### PR DESCRIPTION
This PR increases the timeout for the `GCSObjectExistenceSensor` in `runtime_sensor_timeout_dag.py` from 60 to 120 seconds to prevent `AirflowSensorTimeout` errors.