### PR TITLE
Fix: Cast XCom value to int in runtime_xcom_type_error_dag.py

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -10,13 +10,16 @@ def push_a_string_value(**context):
     context["ti"].xcom_push(key="my_value", value="500")
 
 def pull_and_do_math(**context):
-    """Pulls the XCom value and tries to perform math with it."""
+    """
+    Pulls the XCom value and tries to perform math with it.
+    """
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    # Fix: Cast the pulled_value to an integer before performing addition.
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR fixes the `TypeError: can only concatenate str (not "int") to str` in `dags/runtime_xcom_type_error_dag.py` by casting the XCom value to an integer before performing the addition.