### PR TITLE
Fix: Cast XCom value to int in runtime_xcom_type_error_dag.py

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -16,7 +16,7 @@ def pull_and_do_math(**context):
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    result = int(pulled_value) + 100 # Cast pulled_value to int
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR addresses the `TypeError: can only concatenate str (not "int") to str` in `runtime_xcom_type_error_dag.py` by casting the XCom value to an integer before performing the addition.