### PR TITLE
Fix: Define 'my_undefined_data_path' in runtime_name_error_dag

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -12,6 +12,7 @@ def process_data():
     logging.info("Starting the data processing task.")
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
+    my_undefined_data_path = "/tmp/data" # Defining the missing variable
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This PR defines the missing variable `my_undefined_data_path` in the `process_data` function of `runtime_name_error_dag.py` to resolve the `NameError`.