### PR TITLE
Fix: Cast XCom pulled value to int in runtime_xcom_type_error_dag

### DIFF
--- a/dags/runtime_xcom_type_error_dag.py
+++ b/dags/runtime_xcom_type_error_dag.py
@@ -5,18 +5,22 @@ from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 
 def push_a_string_value(**context):
-    """Pushes a string value to XComs."""
+    """
+Pushes a string value to XComs.
+"""
     logging.info("Pushing the string '500' to XComs.")
     context["ti"].xcom_push(key="my_value", value="500")
 
 def pull_and_do_math(**context):
-    """Pulls the XCom value and tries to perform math with it."""
+    """
+Pulls the XCom value and tries to perform math with it.
+"""
     pulled_value = context["ti"].xcom_pull(key="my_value", task_ids="push_task")
     logging.info(f"Pulled value '{pulled_value}' of type {type(pulled_value)} from XComs.")
     
     # THE ERROR IS HERE: You cannot add a string and an integer.
     # This will raise a TypeError.
-    result = pulled_value + 100
+    result = int(pulled_value) + 100
     logging.info(f"This will not be logged. The result was {result}")
 
 with DAG(


### PR DESCRIPTION
This PR casts the `pulled_value` from XComs to an integer before performing addition in `runtime_xcom_type_error_dag.py` to resolve the `TypeError`.