### PR TITLE
Fix: SyntaxError in dag_with_import_error.py

### DIFF
--- a/dags/dag_with_import_error.py
+++ b/dags/dag_with_import_error.py
@@ -10,8 +10,7 @@ with DAG(
     schedule=None,
     catchup=False,
     tags=["example", "composer-v2", "error", "import-error"],
-# The closing parenthesis is missing on the line below!
-as dag:
+) as dag:
     correct_task = BashOperator(
         task_id="this_will_never_run",
         bash_command="echo 'This task is part of a broken DAG.'",


### PR DESCRIPTION
This PR fixes the SyntaxError in dag_with_import_error.py by adding the missing closing parenthesis to the DAG definition.