### PR TITLE
Fix: NameError in runtime_name_error_dag.py

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,6 +10,7 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
+    my_undefined_data_path = "/tmp"  # Defining the missing variable
     # Imagine this variable was supposed to be passed in or defined earlier.
     # Because it's not defined, this line will fail.
     data_path = my_undefined_data_path + "/source.csv"


### PR DESCRIPTION
This PR fixes the NameError in runtime_name_error_dag.py by defining the `my_undefined_data_path` variable before its use. This resolves the 'name 'my_undefined_data_path' is not defined' error.