### PR TITLE
Fix: Define my_undefined_data_path in runtime_name_error_dag.py

### DIFF
--- a/dags/runtime_name_error_dag.py
+++ b/dags/runtime_name_error_dag.py
@@ -10,8 +10,9 @@ def process_data():
     which will cause a NameError at runtime.
     """
     logging.info("Starting the data processing task.")
-    # Imagine this variable was supposed to be passed in or defined earlier.
-    # Because it's not defined, this line will fail.
+    # Define the variable with a placeholder value.
+    # IMPORTANT: This value should be replaced with the correct data path.
+    my_undefined_data_path = "/tmp/data"
     data_path = my_undefined_data_path + "/source.csv"
     logging.info(f"This will never be logged. Path was: {data_path}")
 


### PR DESCRIPTION
This PR defines the my_undefined_data_path variable with a placeholder value in runtime_name_error_dag.py to resolve a NameError. This value should be replaced with the correct data path.